### PR TITLE
Fix: Prevent background scroll when project modal is open

### DIFF
--- a/src/components/sections/ProjectsSection.tsx
+++ b/src/components/sections/ProjectsSection.tsx
@@ -76,6 +76,19 @@ export const ProjectsSection: React.FC = () => {
   const canvasRef = useRef<HTMLDivElement>(null);
   const sectionRef = useRef<HTMLElement>(null);
 
+  // Effect to disable body scroll when modal is open
+  useEffect(() => {
+    if (selectedProject) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
+    }
+    // Cleanup function to ensure scroll is re-enabled when component unmounts
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, [selectedProject]);
+
   // Mouse tracking for interactive movement
   useEffect(() => {
     const handleMouseMove = (event: MouseEvent) => {


### PR DESCRIPTION
Implemented a scroll lock mechanism for the project details modal in `ProjectsSection.tsx`.

When the modal is active, the `overflow` style of the `document.body` is set to `hidden` to prevent the underlying page content from scrolling. When the modal is closed, the `overflow` style is reset to `auto`, restoring normal scrolling behavior.

This is achieved using a `useEffect` hook that monitors the `selectedProject` state. A cleanup function within the hook ensures that the body scroll is re-enabled if the component unmounts while the modal is open.